### PR TITLE
Guest Info add JNLP Secret variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -404,7 +404,6 @@ public class vSphereCloud extends Cloud {
             final int numberOfExecutors = template.getNumberOfExecutors();
             final String cloneUUID = Long.toString(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()).getLong(), Character.MAX_RADIX);
             final String nodeName = cloneNamePrefix + "_" + cloneUUID;
-            final String nodeName = cloneNamePrefix + "_" + cloneUUID;
             final Callable<Node> provisionNodeCallable = new Callable<Node>() {
                 public Node call() throws Exception {
                     try {

--- a/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/vSphereCloud.java
@@ -21,6 +21,7 @@ import hudson.util.FormValidation;
 import hudson.util.StreamTaskListener;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -401,7 +402,8 @@ public class vSphereCloud extends Cloud {
             final vSphereCloudSlaveTemplate template = whatWeShouldSpinUp.getTemplate();
             final String cloneNamePrefix = template.getCloneNamePrefix();
             final int numberOfExecutors = template.getNumberOfExecutors();
-            final UUID cloneUUID = UUID.randomUUID();
+            final String cloneUUID = Long.toString(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()).getLong(), Character.MAX_RADIX);
+            final String nodeName = cloneNamePrefix + "_" + cloneUUID;
             final String nodeName = cloneNamePrefix + "_" + cloneUUID;
             final Callable<Node> provisionNodeCallable = new Callable<Node>() {
                 public Node call() throws Exception {

--- a/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-guestInfoProperties.html
+++ b/src/main/resources/org/jenkinsci/plugins/vSphereCloudSlaveTemplate/help-guestInfoProperties.html
@@ -16,6 +16,7 @@ Variables which can be used within the values of these properties include
 <li>All variables exposed from "this" node's own properties, e.g. tool locations.</li>
 <li>Environment variables available in build steps that are not build-dependent:
 <tt>JENKINS_URL</tt>,
+<tt>JNLP_SECRET</tt>,
 <tt>NODE_NAME</tt>,
 <tt>NODE_LABELS</tt>.
 </li>


### PR DESCRIPTION
I added the ${JNLP_SECRET} to be used by the cloud template, this is very usefull if you want to execute jenkins slave on windows machine auto deployed and you are using secured slave connections.

And also The UUID generated to have random VM name I reduced using base MAX_RADIX, same random security but shorter name, this is because maybe you want to use the vmname to create directories, and in windows we have a limit of chars for the path
